### PR TITLE
Fix VitaSDK includes

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,9 +8,9 @@
 #include <psp2kern/io/fcntl.h>
 #include <psp2kern/display.h>
 #include <psp2kern/power.h>
-#include <psp2kern/syscon.h>
+#include <psp2kern/kernel/syscon.h>
 #include <psp2kern/kernel/sysroot.h>
-#include <psp2kern/uart.h>
+#include <psp2kern/kernel/uart.h>
 #include <taihen.h>
 #include "config.h"
 


### PR DESCRIPTION
``syscon`` and ``uart`` includes in main.c doesn't seems to be correct.

Build working under Ubuntu 22.04.3 LTS with a fresh installation of the VitaSDK.